### PR TITLE
Working babel-plugin-macros transformer

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -44,6 +44,7 @@
     "acorn-to-esprima": "^1.0.2",
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.2.3",
+    "babel-plugin-macros": "^2.1.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-env": "^1.2.2",
     "babel-preset-es2015": "^6.24.1",

--- a/website/src/parsers/js/transformers/babel-macros/babel-plugin-macros.js
+++ b/website/src/parsers/js/transformers/babel-macros/babel-plugin-macros.js
@@ -1,0 +1,263 @@
+/** 
+ *  Just for the proof of concept.
+ * 
+ *  I had to modifiy the BablePluginMacro 
+ *  to be able to inject a custom require function 
+ *  that would always resolve to the same macro.
+ * 
+ *  No idea if this could be worked around with webpack...
+ */
+
+
+const p = require('path')
+// const printAST = require('ast-pretty-print')
+
+const macrosRegex = /[./]macro(\.js)?$/
+
+// https://stackoverflow.com/a/32749533/971592
+class MacroError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'MacroError'
+    /* istanbul ignore else */
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor)
+    } else if (!this.stack) {
+      this.stack = new Error(message).stack
+    }
+  }
+}
+
+function createMacro(macro, options = {}) {
+  if (options.configName === 'options') {
+    throw new Error(
+      `You cannot use the configName "options". It is reserved for babel-plugin-macros.`,
+    )
+  }
+  macroWrapper.isBabelMacro = true
+  macroWrapper.options = options
+  return macroWrapper
+
+  function macroWrapper(args) {
+    const {source, isBabelMacrosCall} = args
+    if (!isBabelMacrosCall) {
+      throw new MacroError(
+        `The macro you imported from "${source}" is being executed outside the context of compilation with babel-plugin-macros. ` +
+          `This indicates that you don't have the babel plugin "babel-plugin-macros" configured correctly. ` +
+          `Please see the documentation for how to configure babel-plugin-macros properly: ` +
+          'https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md',
+      )
+    }
+    return macro(args)
+  }
+}
+
+function macrosPlugin(babel, { require: _require }) {
+
+  function interopRequire(path) {
+    // eslint-disable-next-line import/no-dynamic-require
+    const o = _require ? _require(path) : require(path);
+    return o && o.__esModule && o.default ? o.default : o
+  }
+
+  return {
+    name: 'macros',
+    visitor: {
+      ImportDeclaration(path, state) {
+        const isMacros = looksLike(path, {
+          node: {
+            source: {
+              value: v => macrosRegex.test(v),
+            },
+          },
+        })
+        if (!isMacros) {
+          return
+        }
+        const imports = path.node.specifiers.map(s => ({
+          localName: s.local.name,
+          importedName:
+            s.type === 'ImportDefaultSpecifier' ? 'default' : s.imported.name,
+        }))
+        const source = path.node.source.value
+        applyMacros({
+          path,
+          imports,
+          source,
+          state,
+          babel,
+          interopRequire,
+        })
+        path.remove()
+      },
+      VariableDeclaration(path, state) {
+        const isMacros = child =>
+          looksLike(child, {
+            node: {
+              init: {
+                callee: {
+                  type: 'Identifier',
+                  name: 'require',
+                },
+                arguments: args =>
+                  args.length === 1 && macrosRegex.test(args[0].value),
+              },
+            },
+          })
+
+        path
+          .get('declarations')
+          .filter(isMacros)
+          .forEach(child => {
+            const imports = child.node.id.name
+              ? [{localName: child.node.id.name, importedName: 'default'}]
+              : child.node.id.properties.map(property => ({
+                  localName: property.value.name,
+                  importedName: property.key.name,
+                }))
+
+            const call = child.get('init')
+            const source = call.node.arguments[0].value
+            applyMacros({
+              path: call,
+              imports,
+              source,
+              state,
+              babel,
+              interopRequire,
+            })
+
+            child.remove()
+          })
+      },
+    },
+  }
+}
+
+// eslint-disable-next-line complexity
+function applyMacros({path, imports, source, state, babel, interopRequire}) {
+  const {file: {opts: {filename}}} = state
+  let hasReferences = false
+  const referencePathsByImportName = imports.reduce(
+    (byName, {importedName, localName}) => {
+      byName[importedName] = path.scope.getBinding(localName).referencePaths
+      hasReferences = hasReferences || Boolean(byName[importedName].length)
+      return byName
+    },
+    {},
+  )
+  if (!hasReferences) {
+    return
+  }
+  let requirePath = source
+  const isRelative = source.indexOf('.') === 0
+  if (isRelative) {
+    requirePath = p.join(p.dirname(getFullFilename(filename)), source)
+  }
+  const macro = interopRequire(requirePath)
+  if (!macro.isBabelMacro) {
+    throw new Error(
+      // eslint-disable-next-line prefer-template
+      `The macro imported from "${source}" must be wrapped in "createMacro" ` +
+        `which you can get from "babel-plugin-macros". ` +
+        `Please refer to the documentation to see how to do this properly: https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#writing-a-macro`,
+    )
+  }
+  const config = getConfig(macro, filename, source)
+  try {
+    macro({
+      references: referencePathsByImportName,
+      state,
+      babel,
+      config,
+      isBabelMacrosCall: true,
+    })
+  } catch (error) {
+    if (error.name === 'MacroError') {
+      throw error
+    }
+    error.message = `${source}: ${error.message}`
+    if (!isRelative) {
+      error.message = `${
+        error.message
+      } Learn more: https://www.npmjs.com/package/${source.replace(
+        /(\/.*)/g,
+        '',
+      )}`
+    }
+    throw error
+  }
+}
+
+// eslint-disable-next-line consistent-return
+function getConfig(macro, filename, source) {
+  if (macro.options.configName) {
+    try {
+      // lazy-loading it here to avoid perf issues of loading it up front.
+      // No I did not measure. Yes I'm a bad person.
+      // FWIW, this thing told me that cosmiconfig is 227.1 kb of minified JS
+      // so that's probably significant... https://bundlephobia.com/result?p=cosmiconfig@3.1.0
+      // Note that cosmiconfig will cache the babel-plugin-macros config 👍
+      const loaded = require('cosmiconfig')('babel-plugin-macros', {
+        packageProp: 'babelMacros',
+        rc: '.babel-plugin-macrosrc',
+        js: 'babel-plugin-macros.config.js',
+        rcExtensions: true,
+        sync: true,
+      }).load(filename)
+      if (loaded) {
+        return loaded.config[macro.options.configName]
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `There was an error trying to load the config "${
+          macro.options.configName
+        }" ` +
+          `for the macro imported from "${source}. ` +
+          `Please see the error thrown for more information.`,
+      )
+      throw error
+    }
+  }
+}
+
+/*
+ istanbul ignore next
+ because this is hard to test
+ and not worth it...
+ */
+function getFullFilename(filename) {
+  if (p.isAbsolute(filename)) {
+    return filename
+  }
+  return p.join(process.cwd(), filename)
+}
+
+function looksLike(a, b) {
+  return (
+    a &&
+    b &&
+    Object.keys(b).every(bKey => {
+      const bVal = b[bKey]
+      const aVal = a[bKey]
+      if (typeof bVal === 'function') {
+        return bVal(aVal)
+      }
+      return isPrimitive(bVal) ? bVal === aVal : looksLike(aVal, bVal)
+    })
+  )
+}
+
+function isPrimitive(val) {
+  // eslint-disable-next-line
+  return val == null || /^[sbn]/.test(typeof val)
+}
+
+
+
+module.exports = macrosPlugin
+Object.assign(module.exports, {
+  createMacro,
+  MacroError,
+})

--- a/website/src/parsers/js/transformers/babel-macros/codeExample.txt
+++ b/website/src/parsers/js/transformers/babel-macros/codeExample.txt
@@ -1,0 +1,17 @@
+// ^^^^^^^^^^^ Above you can try the macro using ^^^^^^^^^^^
+// import MyMacro from 'AnyNameThatEndsIn.macro'
+// MyMacro('Awesome')
+
+
+// `createMacro` is simply a function that ensures your macro is only
+// called in the context of a babel transpilation and will throw an
+// error with a helpful message if someone does not have babel-plugin-macros
+// configured correctly
+module.exports = createMacro(myMacro)
+
+function myMacro({references, state, babel}) {
+  // state is the second argument you're passed to a visitor in a
+  // normal babel plugin. `babel` is the `babel-plugin-macros` module.
+  // do whatever you like to the AST paths you find in `references`
+  // read more below...
+}

--- a/website/src/parsers/js/transformers/babel-macros/index.js
+++ b/website/src/parsers/js/transformers/babel-macros/index.js
@@ -1,0 +1,60 @@
+import compileModule from '../../../utils/compileModule';
+import pkg from 'babel-plugin-macros/package';
+
+const ID = 'babel-macros';
+
+import macro,  {createMacro, MacroError} from './babel-plugin-macros';
+
+export default {
+  id: ID,
+  displayName: ID,
+  version: pkg.version,
+  homepage: pkg.homepage,
+
+  defaultParserID: 'babylon7',
+
+  loadTransformer(callback) {
+    require([
+      'babel7',
+      'recast',
+    ], (babel, recast) => callback({ babel, recast }));
+  },
+
+  transform({ babel, recast }, transformCode, code) {
+    let transform = compileModule( // eslint-disable-line no-shadow
+      transformCode,
+      {createMacro, MacroError}
+    );
+
+    return babel.transform(code, {
+      parserOpts: {
+        parser: recast.parse,
+        plugins: [
+          'asyncGenerators',
+          'classPrivateProperties',
+          'classProperties',
+          'decorators',
+          'doExpressions',
+          'exportExtensions',
+          'flow',
+          'functionSent',
+          'functionBind',
+          'jsx',
+          'objectRestSpread',
+          'dynamicImport',
+          'numericSeparator',
+          'optionalChaining',
+          'importMeta',
+          'bigInt',
+          'optionalCatchBinding',
+          'pipelineOperator',
+        ],
+      },
+      generatorOpts: {
+        generator: recast.print,
+      },
+      plugins: [macro(babel, {require: () => transform})],
+      sourceMaps: true,
+    });
+  },
+};

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -694,6 +694,12 @@ babel-plugin-jscript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz#8f342c38276e87a47d5fa0a8bd3d5eb6ccad8fcc"
 
+babel-plugin-macros@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.1.0.tgz#e978fd4c5ee9cca73a809c176524c2e9f4dcccbf"
+  dependencies:
+    cosmiconfig "^4.0.0"
+
 babel-plugin-member-expression-literals@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz#cc5edb0faa8dc927170e74d6d1c02440021624d3"
@@ -1872,6 +1878,15 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
+
 create-ecdh@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.0.tgz#888c723596cdf7612f6498233eebd7a35301737d"
@@ -2341,7 +2356,7 @@ errno@^0.1.3:
   dependencies:
     prr "~0.0.0"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -3837,7 +3852,7 @@ js-yaml@3.4.5:
     argparse "^1.0.2"
     esprima "^2.6.0"
 
-js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.5.2, js-yaml@^3.9.1:
+js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.5.2, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3895,6 +3910,10 @@ jsesc@~0.5.0:
 json-loader@^0.5.3, json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz#50183cd1b2d25275de069e9e71b467ac9eab973a"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -4830,6 +4849,13 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse5@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
@@ -5748,6 +5774,10 @@ require-directory@^2.1.1:
 require-from-string@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
 
 require-main-filename@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This transformer is based in babel7 and makes it possible to develop and show off [babel-plugin-macros](https://github.com/kentcdodds/babel-plugin-macros). Had to modify the source of babel-plugin-macros quite heavily to get this to work. That is the reason this is not an actual PR against astexplorer, this is a proof of concept and I would like to use this as a foundation to show of what would be possible if the changes I made to `babel-plugin-macros` would get merged into the main project. I feel like there should be a better way to handle this from within webpack.

I will add some comments to the relevant changes to explain what needs to change in babel plugin macro.
You can give this a try [https://astexplorer.dev.weinberg.me/](https://astexplorer.dev.weinberg.me/). (Select Transform -> babel-macros)

